### PR TITLE
Feat/refinar responsive en probadores

### DIFF
--- a/src/components/MarcaContenido.jsx
+++ b/src/components/MarcaContenido.jsx
@@ -33,6 +33,9 @@ function MarcaContenido({
   avatarType,
   onAvatarTypeChange,
   user,
+  isDrawerOpen,
+  setIsDrawerOpen,
+  setAutoOpenDisabled,
 }) {
   const [soloFavoritosSuperiores, setSoloFavoritosSuperiores] = useState(false);
   const [soloFavoritosInferiores, setSoloFavoritosInferiores] = useState(false);
@@ -53,6 +56,17 @@ function MarcaContenido({
         : inferioresBuscados,
     };
   }, [marcaDetail, soloFavoritosSuperiores, soloFavoritosInferiores, busqueda]);
+
+  function handleOnOpenChange(open) {
+    setIsDrawerOpen(open);
+    if (!open) setAutoOpenDisabled(true);
+  }
+
+  function handleCombineInDrawer() {
+    setIsDrawerOpen(true);
+    setAutoOpenDisabled(true);
+    onCombinarPrendas(avatarType);
+  }
 
   return (
     <div className="w-full lg:w-2/3 flex flex-col px-2">
@@ -88,7 +102,7 @@ function MarcaContenido({
               </div>
             </div>
 
-            <div className="flex items-center gap-4">
+            <div className="flex items-center gap-4 flex-wrap">
               <AvatarDropdown
                 avatarType={avatarType}
                 onAvatarTypeChange={onAvatarTypeChange}
@@ -107,10 +121,21 @@ function MarcaContenido({
                 </Button>
               </div>
 
-              <Drawer>
+              <div className="lg:hidden">
+                <Button
+                  onClick={() => setIsDrawerOpen(true)}
+                  disabled={!resultado && !modeloUrl}
+                  variant="primary"
+                  width="fit"
+                >
+                  Ver combinación
+                </Button>
+              </div>
+
+              <Drawer open={isDrawerOpen} onOpenChange={handleOnOpenChange}>
                 <DrawerTrigger asChild>
                   <Button
-                    onClick={() => onCombinarPrendas(avatarType)}
+                    onClick={handleCombineInDrawer}
                     className="lg:hidden text-nowrap"
                     width="fit"
                     disabled={!canCombine || loadingCombinacion}
@@ -133,7 +158,9 @@ function MarcaContenido({
 
                   <div className="p-4 border-t text-white border-gray/20 bg-background flex justify-end">
                     <DrawerClose asChild>
-                      <Button>Cerrar</Button>
+                      <Button onClick={() => setIsDrawerOpen(false)}>
+                        Cerrar
+                      </Button>
                     </DrawerClose>
                   </div>
                 </DrawerContent>

--- a/src/components/MarcaContenido.jsx
+++ b/src/components/MarcaContenido.jsx
@@ -215,7 +215,7 @@ function MarcaContenido({
                   <span className="text-sm text-white">Solo favoritos</span>
                 </label>
               </div>
-              <div className="flex flex-wrap gap-4 mx-8 items-center">
+              <div className="grid justify-center grid-cols-[repeat(auto-fit,160px)] mx-4 my-8 gap-6 md:gap-8">
                 {prendasCategorizadas.superiores.map((prenda, index) => (
                   <PrendaGalleryCard
                     key={`superior-${index}`}
@@ -260,7 +260,7 @@ function MarcaContenido({
                   <span className="text-sm text-white">Solo favoritos</span>
                 </label>
               </div>
-              <div className="flex flex-wrap gap-4 mx-8 items-center">
+              <div className="grid justify-center grid-cols-[repeat(auto-fit,160px)] mx-4 my-8 gap-6 md:gap-8">
                 {prendasCategorizadas.inferiores.map((prenda, index) => (
                   <PrendaGalleryCard
                     key={`inferior-${index}`}

--- a/src/components/ProbadorContenido.jsx
+++ b/src/components/ProbadorContenido.jsx
@@ -37,15 +37,28 @@ export default function ProbadorContenido({
   avatarType,
   onAvatarTypeChange,
   user,
+  isDrawerOpen,
+  setIsDrawerOpen,
+  setAutoOpenDisabled,
 }) {
   const [busqueda, setBusqueda] = useState("");
-
   const prendasFiltradas = searchGarments(prendas, busqueda);
 
   const prendasCategorizadasFiltradas = {
-    superiores: prendasFiltradas.filter(p => p.tipo === "superior"),
-    inferiores: prendasFiltradas.filter(p => p.tipo === "inferior"),
+    superiores: prendasFiltradas.filter((p) => p.tipo === "superior"),
+    inferiores: prendasFiltradas.filter((p) => p.tipo === "inferior"),
   };
+
+  function handleOnOpenChange(open) {
+    setIsDrawerOpen(open);
+    if (!open) setAutoOpenDisabled(true);
+  }
+
+  function handleCombineInDrawer() {
+    setIsDrawerOpen(true);
+    setAutoOpenDisabled(true);
+    onCombinarPrendas(avatarType);
+  }
 
   return (
     <div className="w-full lg:w-2/3 flex flex-col px-2">
@@ -78,10 +91,21 @@ export default function ProbadorContenido({
                 </Button>
               </div>
 
-              <Drawer>
+              <div className="lg:hidden">
+                <Button
+                  onClick={() => setIsDrawerOpen(true)}
+                  disabled={!resultado && !modeloUrl}
+                  variant="primary"
+                  width="fit"
+                >
+                  Ver combinación
+                </Button>
+              </div>
+
+              <Drawer open={isDrawerOpen} onOpenChange={handleOnOpenChange}>
                 <DrawerTrigger asChild>
                   <Button
-                    onClick={() => onCombinarPrendas(avatarType)}
+                    onClick={handleCombineInDrawer}
                     className="lg:hidden text-nowrap"
                     width="fit"
                     disabled={!canCombine || loadingCombinacion}
@@ -104,7 +128,9 @@ export default function ProbadorContenido({
 
                   <div className="p-4 border-t text-white border-gray/20 bg-background flex justify-end">
                     <DrawerClose asChild>
-                      <Button>Cerrar</Button>
+                      <Button onClick={() => setIsDrawerOpen(false)}>
+                        Cerrar
+                      </Button>
                     </DrawerClose>
                   </div>
                 </DrawerContent>

--- a/src/components/ProbadorContenido.jsx
+++ b/src/components/ProbadorContenido.jsx
@@ -161,7 +161,7 @@ export default function ProbadorContenido({
         {prendasFiltradas && prendasFiltradas.length > 0 ? (
           <div className="space-y-6 max-w-5xl mx-auto">
             <div>
-              <div className="bg-gray/5 pt-1 px-2 flex gap-8 justify-between items-center rounded-sm mb-2">
+              <div className="bg-gray/5 pt-1 px-2 flex flex-col sm:flex-row justify-between items-center rounded-sm mb-2">
                 <h5 className="font-semibold">
                   Prendas Superiores (
                   {prendasCategorizadasFiltradas.superiores.length})
@@ -173,7 +173,7 @@ export default function ProbadorContenido({
                 )}
               </div>
 
-              <div className="flex flex-wrap mx-8 items-center gap-6">
+              <div className="grid justify-center grid-cols-[repeat(auto-fit,160px)] mx-4 my-8 gap-6 md:gap-8">
                 {prendasCategorizadasFiltradas.superiores.map(
                   (prenda, index) => (
                     <PrendaGalleryCard
@@ -196,7 +196,7 @@ export default function ProbadorContenido({
             </div>
 
             <div>
-              <div className="bg-gray/5 pt-1 px-2 flex gap-8 justify-between items-center rounded-sm mb-2">
+              <div className="bg-gray/5 pt-1 px-2 flex flex-col sm:flex-row justify-between items-center rounded-sm mb-2">
                 <h5 className="font-semibold">
                   Prendas Inferiores (
                   {prendasCategorizadasFiltradas.inferiores.length})
@@ -208,7 +208,7 @@ export default function ProbadorContenido({
                 )}
               </div>
 
-              <div className="flex flex-wrap mx-8 items-center gap-6">
+              <div className="grid justify-center grid-cols-[repeat(auto-fit,160px)] mx-2 md:mx-4 my-8 gap-5 md:gap-7">
                 {prendasCategorizadasFiltradas.inferiores.map(
                   (prenda, index) => (
                     <PrendaGalleryCard

--- a/src/components/shared/Button.jsx
+++ b/src/components/shared/Button.jsx
@@ -1,72 +1,86 @@
 import { forwardRef } from "react";
 
-const Button = forwardRef(({
-  children,
-  variant = "default",
-  size = "md",
-  color = "secondary",
-  text,
-  disabled = false,
-  className = "",
-  width = "full",
-  ...props
-}, ref) => {
-  const baseStyles = "font-family-secondary h-10 inline-flex items-center justify-center gap-2 font-medium cursor-pointer transition-all duration-200 focus:outline-none disabled:opacity-50 disabled:cursor-default";
+const Button = forwardRef(
+  (
+    {
+      children,
+      variant = "default",
+      size = "md",
+      color = "secondary",
+      text,
+      disabled = false,
+      className = "",
+      width = "full",
+      ...props
+    },
+    ref
+  ) => {
+    const baseStyles =
+      "font-family-secondary h-9 inline-flex items-center justify-center gap-2 font-medium cursor-pointer transition-all duration-200 focus:outline-none disabled:opacity-50 disabled:cursor-default";
 
-  const getVariantStyles = (variant, color, textColor) => {
-    const defaultTextColor = textColor || (variant === "default" || variant === "error" ? "white" : color);
-    const hoverTextColor = textColor || "white";
+    const getVariantStyles = (variant, color, textColor) => {
+      const defaultTextColor =
+        textColor ||
+        (variant === "default" || variant === "error" ? "white" : color);
+      const hoverTextColor = textColor || "white";
 
-    const variants = {
-      default: `${color ? `bg-${color}` : "bg-secondary"} text-${defaultTextColor} hover:enabled:bg-${color}/80 focus:ring-tertiary border border-transparent`,
-      outline: `bg-transparent border border-${color} text-${defaultTextColor} hover:enabled:bg-${color} hover:enabled:text-${hoverTextColor}`,
-      ghost: `bg-transparent border border-transparent text-${defaultTextColor} hover:enabled:bg-gray/10`,
-      text: `bg-transparent border-none text-${defaultTextColor} hover:enabled:text-${defaultTextColor}/80 p-0`,
-      error: `bg-error text-${textColor || "white"} hover:enabled:bg-error/80 border border-transparent`
-    };
-    return variants[variant] || variants.default;
-  };
-
-  const sizes = {
-    sm: "px-3 py-1.5 text-sm rounded-sm",
-    md: "px-4 py-2 text-base rounded-sm",
-    lg: "px-6 py-3 text-lg rounded-md"
-  };
-
-  const getWidthClass = (width) => {
-    const widthClasses = {
-      full: "w-full",
-      fit: "w-fit",
-      auto: "w-auto",
-      max: "w-max",
-      min: "w-min"
+      const variants = {
+        default: `${
+          color ? `bg-${color}` : "bg-secondary"
+        } text-${defaultTextColor} hover:enabled:bg-${color}/80 focus:ring-tertiary border border-transparent`,
+        outline: `bg-transparent border border-${color} text-${defaultTextColor} hover:enabled:bg-${color} hover:enabled:text-${hoverTextColor}`,
+        ghost: `bg-transparent border border-transparent text-${defaultTextColor} hover:enabled:bg-gray/10`,
+        text: `bg-transparent border-none text-${defaultTextColor} hover:enabled:text-${defaultTextColor}/80 p-0`,
+        error: `bg-error text-${
+          textColor || "white"
+        } hover:enabled:bg-error/80 border border-transparent`,
+        primary: `bg-secondary/30 text-white hover:enabled:bg-primary/80 border border-secondary`,
+      };
+      return variants[variant] || variants.default;
     };
 
-    // Si es un número, agregar w- al principio
-    if (/^\d+$/.test(width)) {
-      return `w-${width}`;
-    }
+    const sizes = {
+      sm: "px-2.5 py-1.5 text-sm rounded-sm",
+      md: "px-3.5 py-2 text-base rounded-sm",
+      lg: "px-5.5 py-3 text-lg rounded-md",
+    };
 
-    return widthClasses[width] || "w-full";
-  };
+    const getWidthClass = (width) => {
+      const widthClasses = {
+        full: "w-full",
+        fit: "w-fit",
+        auto: "w-auto",
+        max: "w-max",
+        min: "w-min",
+      };
 
-  const variantStyles = getVariantStyles(variant, color, text);
-  const sizeStyles = sizes[size] || sizes.md;
-  const widthClass = getWidthClass(width);
+      // Si es un número, agregar w- al principio
+      if (/^\d+$/.test(width)) {
+        return `w-${width}`;
+      }
 
-  const combinedClassName = `${baseStyles} ${variantStyles} ${sizeStyles} ${widthClass} ${className}`.trim();
+      return widthClasses[width] || "w-full";
+    };
 
-  return (
-    <button
-      ref={ref}
-      className={combinedClassName}
-      disabled={disabled}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-});
+    const variantStyles = getVariantStyles(variant, color, text);
+    const sizeStyles = sizes[size] || sizes.md;
+    const widthClass = getWidthClass(width);
+
+    const combinedClassName =
+      `${baseStyles} ${variantStyles} ${sizeStyles} ${widthClass} ${className}`.trim();
+
+    return (
+      <button
+        ref={ref}
+        className={combinedClassName}
+        disabled={disabled}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
 
 Button.displayName = "Button";
 

--- a/src/pages/Combinaciones.jsx
+++ b/src/pages/Combinaciones.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { BookHeart, CircleArrowLeft } from "lucide-react";
 import { usePerfil } from "../hooks/usePerfil.jsx";
@@ -45,24 +45,24 @@ export default function Combinaciones() {
   const [combinacionSeleccionada, setCombinacionSeleccionada] = useState(null);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [combinacionAEliminar, setCombinacionAEliminar] = useState(null);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [autoOpenDisabled, setAutoOpenDisabled] = useState(false);
+  const [highlightButton, setHighlightButton] = useState(false);
   const navigate = useNavigate();
 
   const handleToggleFavorita = async (combinacion) => {
-      setCombinacionAEliminar(combinacion);
-      setShowConfirmDialog(true);
+    setCombinacionAEliminar(combinacion);
+    setShowConfirmDialog(true);
   };
 
   const confirmarEliminacion = async () => {
     if (!combinacionAEliminar) return;
 
-    const codigoCombinacion =
-      combinacionAEliminar.combinationUrl;
+    const codigoCombinacion = combinacionAEliminar.combinationUrl;
 
     try {
       // Primero hacer la llamada al servidor
-      await toggleCombinacionFavorita(
-        codigoCombinacion,
-      );
+      await toggleCombinacionFavorita(codigoCombinacion);
 
       // Solo si la operación fue exitosa, actualizar el estado local
       eliminarCombinacionLocal(codigoCombinacion);
@@ -74,7 +74,6 @@ export default function Combinaciones() {
 
       setShowConfirmDialog(false);
       setCombinacionAEliminar(null);
-
     } catch (error) {
       console.error("Error al eliminar combinación de favoritos:", error);
       // Si falla, cerrar el diálogo pero mantener el estado
@@ -93,17 +92,30 @@ export default function Combinaciones() {
       setCombinacionSeleccionada(null);
     } else {
       setCombinacionSeleccionada(combinacion);
+
+      setHighlightButton(true);
+      setTimeout(() => setHighlightButton(false), 800);
     }
 
     limpiarResultado();
     limpiarModelo();
   };
 
+  function handleOnOpenChange(open) {
+    setIsDrawerOpen(open);
+    if (!open) setAutoOpenDisabled(true);
+  }
+
+  function handleCombineInDrawer() {
+    setIsDrawerOpen(true);
+    setAutoOpenDisabled(true);
+    handleProbarCombinacion();
+  }
+
   const handleProbarCombinacion = async () => {
     if (combinacionSeleccionada) {
       limpiarResultado();
       limpiarModelo();
-
 
       // Establecer resultado usando la imagen de la combinación favorita
       const resultadoCombinacion = {
@@ -120,6 +132,25 @@ export default function Combinaciones() {
       await generarModelo3D(resultado);
     }
   };
+
+  useEffect(() => {
+    const handleResize = () => {
+      const isMobile = window.innerWidth < 1024;
+
+      if (isMobile && (resultado || modeloUrl) && !autoOpenDisabled) {
+        setIsDrawerOpen(true);
+        setAutoOpenDisabled(true);
+      }
+
+      if (!isMobile) {
+        if (isDrawerOpen) setIsDrawerOpen(false);
+        if (autoOpenDisabled) setAutoOpenDisabled(false);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [resultado, modeloUrl, autoOpenDisabled, isDrawerOpen]);
 
   if (loading) {
     return (
@@ -176,51 +207,57 @@ export default function Combinaciones() {
               </div>
 
               <div className="flex not-sm:flex-col not-lg:w-full items-center gap-4">
-                <>
-                  <div className="hidden lg:inline-flex">
+                <div className="hidden lg:inline-flex">
+                  <Button
+                    onClick={handleProbarCombinacion}
+                    disabled={loadingCombinacion || !combinacionSeleccionada}
+                    width="full"
+                    className={`text-nowrap transition-all duration-300 ${
+                      highlightButton
+                        ? "animate-pulse scale-103 border border-primary/40"
+                        : ""
+                    }`}
+                  >
+                    {loadingCombinacion ? "Cargando..." : "Ver combinación"}
+                  </Button>
+                </div>
+
+                <Drawer open={isDrawerOpen} onOpenChange={handleOnOpenChange}>
+                  <DrawerTrigger asChild>
                     <Button
-                      onClick={handleProbarCombinacion}
+                      onClick={handleCombineInDrawer}
                       disabled={loadingCombinacion || !combinacionSeleccionada}
-                      width="full"
-                      className="text-nowrap"
+                      className={`lg:hidden text-nowrap transition-all duration-300 ${
+                        highlightButton
+                          ? "animate-pulse scale-102 border border-primary/40"
+                          : ""
+                      }`}
                     >
-                      {loadingCombinacion ? "Cargando..." : "Ver combinación"}
+                      {loadingCombinacion ? "Cargando..." : "Ver combinación"}{" "}
                     </Button>
-                  </div>
+                  </DrawerTrigger>
+                  <DrawerContent className="h-[90dvh] flex flex-col bg-black/95 lg:hidden">
+                    <div className="flex-1 overflow-y-auto pb-2">
+                      <Panel
+                        loadingCombinacion={loadingCombinacion}
+                        resultado={resultado}
+                        errorCombinacion={errorCombinacion}
+                        errorModelo3D={errorModelo3D}
+                        modeloUrl={modeloUrl}
+                        loadingModelo3D={loadingModelo3D}
+                        onGenerarModelo3D={handleGenerarModelo3D}
+                      />
+                    </div>
 
-                  <Drawer>
-                    <DrawerTrigger asChild>
-                      <Button
-                        onClick={handleProbarCombinacion}
-                        className="lg:hidden text-nowrap"
-                        disabled={
-                          loadingCombinacion || !combinacionSeleccionada
-                        }
-                      >
-                        {loadingCombinacion ? "Cargando..." : "Ver combinación"}{" "}
-                      </Button>
-                    </DrawerTrigger>
-                    <DrawerContent className="h-[90dvh] flex flex-col bg-black/95 lg:hidden">
-                      <div className="flex-1 overflow-y-auto pb-2">
-                        <Panel
-                          loadingCombinacion={loadingCombinacion}
-                          resultado={resultado}
-                          errorCombinacion={errorCombinacion}
-                          errorModelo3D={errorModelo3D}
-                          modeloUrl={modeloUrl}
-                          loadingModelo3D={loadingModelo3D}
-                          onGenerarModelo3D={handleGenerarModelo3D}
-                        />
-                      </div>
-
-                      <div className="p-4 border-t text-white border-gray/20 bg-background flex justify-end">
-                        <DrawerClose asChild>
-                          <Button>Cerrar</Button>
-                        </DrawerClose>
-                      </div>
-                    </DrawerContent>
-                  </Drawer>
-                </>
+                    <div className="p-4 border-t text-white border-gray/20 bg-background flex justify-end">
+                      <DrawerClose asChild>
+                        <Button onClick={() => setIsDrawerOpen(false)}>
+                          Cerrar
+                        </Button>
+                      </DrawerClose>
+                    </div>
+                  </DrawerContent>
+                </Drawer>
               </div>
             </div>
           </div>

--- a/src/pages/Combinaciones.jsx
+++ b/src/pages/Combinaciones.jsx
@@ -274,7 +274,7 @@ export default function Combinaciones() {
                   Tus Combinaciones ({combinaciones.length})
                 </h5>
 
-                <div className="flex flex-wrap mx-8 text-center items-center gap-6">
+                <div className="grid justify-center grid-cols-[repeat(auto-fit,192px)] mx-4 my-8 gap-6 md:gap-8">
                   {combinaciones.map((combinacion, index) => (
                     <div
                       key={`combinacion-${index}`}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -55,12 +55,14 @@ export default function Home() {
   // Estado para el tipo de avatar seleccionado por el usuario
   const [avatarType, setAvatarType] = useState(() => {
     // Default basado en preferencias del usuario
-    if (user?.avatarUrl) return 'custom';
-    return user?.avatarGenero === 'mujer' ? 'woman' : 'man';
+    if (user?.avatarUrl) return "custom";
+    return user?.avatarGenero === "mujer" ? "woman" : "man";
   });
   const [lastCombination, setLastCombination] = useState(null);
   const [modalSugerenciasAbierto, setModalSugerenciasAbierto] = useState(false);
   const [prendaParaSugerencias, setPrendaParaSugerencias] = useState(null);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [autoOpenDisabled, setAutoOpenDisabled] = useState(false);
 
   const handleSelectPrenda = (prenda) => {
     if (prenda.tipo === "superior") {
@@ -133,6 +135,7 @@ export default function Home() {
         sugerencia.bottomGarment,
         user
       );
+      setIsDrawerOpen(true);
     } catch (error) {
       console.error("Error al aplicar sugerencia:", error);
     }
@@ -165,7 +168,12 @@ export default function Home() {
         avatarType: selectedAvatarType,
       });
 
-      await combinarPrendas(selectedAvatarType, selectedSuperior, selectedInferior, user);
+      await combinarPrendas(
+        selectedAvatarType,
+        selectedSuperior,
+        selectedInferior,
+        user
+      );
     }
   };
 
@@ -178,6 +186,25 @@ export default function Home() {
   const handleAvatarTypeChange = (newAvatarType) => {
     setAvatarType(newAvatarType);
   };
+
+  useEffect(() => {
+    const handleResize = () => {
+      const isMobile = window.innerWidth < 1024;
+
+      if (isMobile && (resultado || modeloUrl) && !autoOpenDisabled) {
+        setIsDrawerOpen(true);
+        setAutoOpenDisabled(true);
+      }
+
+      if (!isMobile) {
+        if (isDrawerOpen) setIsDrawerOpen(false);
+        if (autoOpenDisabled) setAutoOpenDisabled(false);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [resultado, modeloUrl, autoOpenDisabled, isDrawerOpen]);
 
   useEffect(() => {
     if (criticalError) {
@@ -241,6 +268,9 @@ export default function Home() {
         avatarType={avatarType}
         onAvatarTypeChange={handleAvatarTypeChange}
         user={user}
+        isDrawerOpen={isDrawerOpen}
+        setIsDrawerOpen={setIsDrawerOpen}
+        setAutoOpenDisabled={setAutoOpenDisabled}
       />
 
       {prendas && prendas.length > 0 && (

--- a/src/pages/MarcaDetalle.jsx
+++ b/src/pages/MarcaDetalle.jsx
@@ -44,15 +44,15 @@ function MarcaDetalle() {
   const { togglePrendaFavorita, toggleCombinacionFavorita } = useFavoritos();
   const [selectedSuperior, setSelectedSuperior] = useState(null);
   const [selectedInferior, setSelectedInferior] = useState(null);
-  // Estado para el tipo de avatar seleccionado por el usuario
   const [avatarType, setAvatarType] = useState(() => {
-    // Default basado en preferencias del usuario
-    if (user?.avatarUrl) return 'custom';
-    return user?.avatarGenero === 'mujer' ? 'woman' : 'man';
+    if (user?.avatarUrl) return "custom";
+    return user?.avatarGenero === "mujer" ? "woman" : "man";
   });
   const [lastCombination, setLastCombination] = useState(null);
   const [modalSugerenciasAbierto, setModalSugerenciasAbierto] = useState(false);
   const [prendaParaSugerencias, setPrendaParaSugerencias] = useState(null);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [autoOpenDisabled, setAutoOpenDisabled] = useState(false);
 
   const handleSelectPrenda = (prenda) => {
     if (prenda.tipo === "superior") {
@@ -90,7 +90,12 @@ function MarcaDetalle() {
         avatarType: selectedAvatarType,
       });
 
-      await combinarPrendas(selectedAvatarType, selectedSuperior, selectedInferior, user);
+      await combinarPrendas(
+        selectedAvatarType,
+        selectedSuperior,
+        selectedInferior,
+        user
+      );
     }
   };
 
@@ -130,6 +135,7 @@ function MarcaDetalle() {
         sugerencia.bottomGarment,
         user
       );
+      setIsDrawerOpen(true);
     } catch (error) {
       console.error("Error al aplicar sugerencia:", error);
     }
@@ -177,6 +183,25 @@ function MarcaDetalle() {
       console.error("Error al cambiar favorito de combinación:", error);
     }
   };
+
+  useEffect(() => {
+    const handleResize = () => {
+      const isMobile = window.innerWidth < 1024;
+
+      if (isMobile && (resultado || modeloUrl) && !autoOpenDisabled) {
+        setIsDrawerOpen(true);
+        setAutoOpenDisabled(true);
+      }
+
+      if (!isMobile) {
+        if (isDrawerOpen) setIsDrawerOpen(false);
+        if (autoOpenDisabled) setAutoOpenDisabled(false);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [resultado, modeloUrl, autoOpenDisabled, isDrawerOpen]);
 
   useEffect(() => {
     if (criticalError) {
@@ -254,6 +279,9 @@ function MarcaDetalle() {
         avatarType={avatarType}
         onAvatarTypeChange={handleAvatarTypeChange}
         user={user}
+        isDrawerOpen={isDrawerOpen}
+        setIsDrawerOpen={setIsDrawerOpen}
+        setAutoOpenDisabled={setAutoOpenDisabled}
       />
 
       {(marcaDetail.garmentTop?.content?.length > 0 ||


### PR DESCRIPTION
Cambios principales implementados:

1. Se ajusto el drawer, para que al generar una combinacion, al achicar la resolucion se muestre el drawer automaticamente, y al agrandar la resolucion esconderlo.
2. Se agrego un boton "Ver combinacion" (unicamente en mobile) para poder ver el modelo, ya que el antiguo boton "Combinar prendas" hace la generacion del modelado, pero al cerrarlo no se podia volver a ver el modelo sin generarlo nuevamente, por lo cual se agrego este boton (no agregado en vistas grandes, ya que el panel se ve siempre de costado, y no se oculta como el drawer)
3. Se ajustó las grillas en combinaciones, home y marcas, para que al ver los items, estos se encuentren siempre centrados.