### PR TITLE
imprv/SCRUM-366-mandar-brandCode

### DIFF
--- a/src/hooks/useDashboard.jsx
+++ b/src/hooks/useDashboard.jsx
@@ -92,7 +92,7 @@ export function useTopCombos(topN = 5, brandCode = "") {
   return { data, loading, error };
 }
 
-export function useColorConversion() {
+export function useColorConversion(brandCode = "") {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -102,7 +102,9 @@ export function useColorConversion() {
       setLoading(true);
       setError(null);
       try {
-        const res = await apiClient.get("/dashboard/color-conversion");
+        const res = await apiClient.get("/dashboard/color-conversion", {
+          params: { brandCode },
+        });
         setData(res.data);
       } catch (err) {
         setError(

--- a/src/pages/BrandDashboard.jsx
+++ b/src/pages/BrandDashboard.jsx
@@ -69,7 +69,8 @@ export default function BrandDashboard() {
     10,
     brandCode
   );
-  const { data: colorConvData, loading: loadingColor } = useColorConversion();
+  const { data: colorConvData, loading: loadingColor } =
+    useColorConversion(brandCode);
 
   const topPruebas = useMemo(() => {
     if (!topPrendasData) return [];


### PR DESCRIPTION
Ahora si:

Ambas prendas de la combinación revisada (prenda superior - prenda inferior) son del MISMO color, solamente se suma una vez el color al data, no dos veces. Ej; antes si se daba este caso ==> blanco = 2, ahora ==> blanco = 1

Si se le envia por params el brandCode, analiza UNICAMENTE los colores de las prendas asociadas a esta marca, no analiza todas las prendas.
